### PR TITLE
indices contraction in correlation_matrix

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -589,7 +589,7 @@ function correlation_matrix(psi::MPS, Op1::AbstractString, Op2::AbstractString; 
     L = ITensor(1.0)
   else
     lind = commonind(psi[start_site], psi[start_site - 1])
-    L = delta(lind, lind')
+    L = delta(dag(lind), lind')
   end
 
   for i in start_site:(end_site - 1)


### PR DESCRIPTION
For the case where (1) the conserved QNs condition is required (2) the start_site does not start from 1, the original code will give an error showing the wrong directions to contract. And the following change can fix the error.